### PR TITLE
Add support for multiarch container images (amd64/arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG=latest
-FROM apluslms/grading-base:$BASE_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grading-base:$BASE_TAG
 
 COPY rootfs /
 

--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:ml-$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:ml-$FULL_TAG
 
 RUN pip_install \
     nbconvert~=7.2.9 \

--- a/Dockerfile.math
+++ b/Dockerfile.math
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:$FULL_TAG
 
 RUN apt_install \
     bc \

--- a/Dockerfile.mec
+++ b/Dockerfile.mec
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:math-$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:math-$FULL_TAG
 
 
 RUN pip_install \

--- a/Dockerfile.ml
+++ b/Dockerfile.ml
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:math-$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:math-$FULL_TAG
 
 RUN pip_install \
     networkx~=2.8.8 \

--- a/Dockerfile.ply
+++ b/Dockerfile.ply
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:$FULL_TAG
 
 # PLY is yet another implementation of lex and yacc for Python,
 # in other words, a parser and lexer generator.

--- a/Dockerfile.psql
+++ b/Dockerfile.psql
@@ -1,9 +1,8 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:$FULL_TAG
 
 RUN apt_install \
     postgresql \
  && pip_install \
     psycopg2-binary \
  && :
-

--- a/Dockerfile.rdf
+++ b/Dockerfile.rdf
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:$FULL_TAG
 
 RUN apt_install \
   python3-rdflib \

--- a/Dockerfile.smt
+++ b/Dockerfile.smt
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:ply-$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:ply-$FULL_TAG
 
 # Solvers for pySMT like msat (MathSAT5) must be compiled from source.
 RUN apt_install \

--- a/Dockerfile.xls
+++ b/Dockerfile.xls
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:$FULL_TAG
 
 RUN apt_install \
     python3-xlrd \

--- a/Dockerfile.y2
+++ b/Dockerfile.y2
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/grade-python:$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/grade-python:$FULL_TAG
 
 ENV XDG_RUNTIME_DIR=/tmp/runtime-nobody
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+docker buildx create --use default
+
 if [ "${DOCKER_TAG#*-}" = "${DOCKER_TAG}" ]; then
     base=${DOCKER_TAG}
     main=
@@ -16,11 +20,10 @@ fi
 if [ "$full" != "latest" ]; then
     echo "############################################################"
     echo "### pulling latest image, so layer cache is update."
-    docker pull $DOCKER_REPO:latest || true
+    docker pull $DOCKER_REPO:latest || true
     echo "############################################################"
 fi
 
-: > tags.txt
 for layer in "" "math" "rdf" "xls" "y2" "ml" "ply" "jupyter" "smt" "mec" "psql"; do
     if [ "$layer" ]; then
         tag="$layer-$full"
@@ -35,13 +38,25 @@ for layer in "" "math" "rdf" "xls" "y2" "ml" "ply" "jupyter" "smt" "mec" "psql";
     echo "### creating '$DOCKER_REPO:$tag' with '$file'"
     echo "############################################################"
 
-    docker build --build-arg "MAIN_TAG=$main" --build-arg "BASE_TAG=$base" \
-                 --build-arg "FULL_TAG=$full" --build-arg "RESULT_TAG=$tag" \
-                 -t $DOCKER_REPO:$tag -f "$file" .
+    if [ "$layer" = "y2" ] || [ "$layer" = "smt" ]; then
+        platform="linux/amd64"
+    else
+        platform="linux/amd64,linux/arm64"
+    fi
+
+    docker buildx build \
+    --build-arg "MAIN_TAG=$main" \
+    --build-arg "BASE_TAG=$base" \
+    --build-arg "FULL_TAG=$full" \
+    --build-arg "RESULT_TAG=$tag" \
+    --push \
+    --platform $platform \
+    -t $DOCKER_REPO:$tag \
+    -f "$file" .
+
     res=$?
     if [ $res -ne 0 ]; then
         echo "Building layer $layer returned $res" >&2
         exit $res
     fi
-    echo "$tag" >> tags.txt
 done

--- a/hooks/push
+++ b/hooks/push
@@ -1,7 +1,3 @@
 #!/bin/sh
 
-while read tag; do
-    echo "### Pushing $DOCKER_REPO:$tag"
-    docker push $DOCKER_REPO:$tag
-done < tags.txt
-rm -f tags.txt
+# This hook is empty because the images were pushed to the registry in the build hook


### PR DESCRIPTION
# Description

**What?**

Add support for automatic building of multi-architecture container images (amd64/arm64).

This PR requires that grading-base has multi-architecture support first.

The y2 and smt layers do not have ARM support since building pyqt6 and pysmt from source fails on the arm64 platform.
Apackage for arm64 PyQt6 seems to be available for Debian Bookworm, but the current grading-base uses Bullseye: https://packages.debian.org/search?keywords=python3-pyqt6

**Why?**

Container images built with support for the ARM architecture perform much better on Apple Silicon laptops.

**How?**

A custom build hook is used to build the images for amd64 and arm64.
The images are pushed to Docker Hub in the build hook.

Links about the docker buildx plugin for future reference:
- https://github.com/docker/buildx
- https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
- https://hub.docker.com/r/tonistiigi/binfmt

# Testing

I tested that Docker Hub Automated Builds work as expected.