### PR TITLE
Support grader tests in the personalized exercise directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Utility commands
 
 In addition to [grading-base](https://github.com/apluslms/grading-base), this container provides following utilities.
 
-* `graderutils [--use-iotester] [--use-rpyc] [--novalidate] [--container] [--show-config] [--develop-mode] -- path_to_test_config`
+* `graderutils [--use-iotester] [--use-rpyc] [--novalidate] [--container] [--show-config] [--develop-mode] [--exercise-path <absolute-path>] -- [<test-config-absolute-path>]`
   * `--use-iotester`
 
     Create the necessary directory structure with the correct permissions required by iotester.
@@ -58,10 +58,14 @@ In addition to [grading-base](https://github.com/apluslms/grading-base), this co
     Display all unhandled exceptions unformatted.
     Also implies `--show-config`.
     By default, exceptions related to improperly configured tests are caught and hidden behind a generic error message.
-    This is to prevent unwanted leaking of grader test details, which might reveal e.g. parts of the model solution, if one is used.
+    This is to prevent unwanted leaking of grader test details, which might reveal e.g. parts of the model solution, if one is used
+  * `--exercise-path`
+
+    Change the directory where grader tests are run. Default is `/exercise`. Personalized programming exercises
+    can set this to `/personalized_exercise`.
 
   Executes `graderutils.main` (or `graderutils.__main__` when `--use-rpyc` flag is set) Python module using `capture` wrapper (check [grading-base](https://github.com/apluslms/grading-base)).
-  Provided arguments, except for `--use-iotester` and `--use-rpyc`, are passed to the Python module.
+  Provided arguments, except for `--use-iotester`, `--use-rpyc`, and `--exercise-path`, are passed to the Python module.
   If there are no arguments, then the module is executed with `/exercise/test_config.yaml` as the first argument.
   In other words, if you define graderutils configuration in `test_config.yaml`, you only need to have `graderutils` in the config.yaml `cmd` field.
 

--- a/bin/graderutils
+++ b/bin/graderutils
@@ -1,31 +1,45 @@
 #!/bin/sh
-export PYTHONPATH=/exercise
-export EXERCISE_PATH=/exercise
 
-# Arguments, except for --use-iotester and --use-rpyc, are collected to variable 'args' and passed on to graderutils
+EXERCISE_PATH=/exercise
+
+# Arguments, except for --use-iotester, --use-rpyc, and --exercise-path, are collected to the variable 'args' and passed onto graderutils
 args=""
 use_iotester=false
 use_rpyc=false
-for arg in "$@"; do
-    case "$arg" in
-        --use-iotester) use_iotester=true ;;
-        --use-rpyc) use_rpyc=true ;;
-        --novalidate) args="${args}${arg} " ;;
-        --container) args="${args}${arg} " ;;
-        --show-config) args="${args}${arg} " ;;
-        --develop-mode) args="${args}${arg} " ;;
-        --) args="${args}${arg} " ;;
+test_config_path=""
+while [ "$1" ]; do
+    case "$1" in
+        --exercise-path)
+            # Check if the next argument exists
+            if [ -z "$2" ] || [ "$(echo "$2" | cut -c1)" = "-" ]; then
+                echo "ERROR: --exercise-path requires a string argument" >&2
+                exit 1
+            fi
+            EXERCISE_PATH="$2"
+            shift 2
+            ;;
+        --use-iotester) use_iotester=true; shift ;;
+        --use-rpyc) use_rpyc=true; shift ;;
+        --novalidate) args="${args}${1} "; shift ;;
+        --container) args="${args}${1} "; shift ;;
+        --show-config) args="${args}${1} "; shift ;;
+        --develop-mode) args="${args}${1} "; shift ;;
+        --) args="${args}${1} "; shift ;;
         -*)
             echo "ERROR: Invalid option '$1' for $0" >&2
-            echo "usage: $0 [--use-iotester] [--use-rpyc] [--novalidate] [--container] [--show-config] [--develop-mode] -- path_to_test_config" >&2
+            echo "Usage: $0 [--use-iotester] [--use-rpyc] [--novalidate] [--container] [--show-config] [--develop-mode] [--exercise-path <absolute-path>] -- [<test-config-absolute-path>]" >&2
             exit 64
             ;;
-        *) args="${args}${arg} " ;;
+        *) args="${args}${1} "; test_config_path="${1}"; shift ;;
     esac
 done
 
-# If 'args' is empty, use default test_config.yaml path
-[ "$args" ] || args="$EXERCISE_PATH"/test_config.yaml
+PYTHONPATH="$EXERCISE_PATH"
+export PYTHONPATH
+export EXERCISE_PATH
+
+# If 'test_config_path' is empty, use default test_config.yaml path
+[ "$test_config_path" ] || args="${args}${EXERCISE_PATH}/test_config.yaml"
 
 if [ "$use_iotester" = true ]; then
     export MODEL_PATH=/model


### PR DESCRIPTION
# Description

**What?**

Allow changing the `PYTHONPATH` and `EXERCISE_PATH` environment variables with a command line argument when using graderutils.

**Why?**

It should be possible to run personalized Python programming exercise grader tests in the `/personalized_exercise` directory, so that the course doesn't have to do hacks to make this possible.

Fixes #7

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that the Y1 December 2022 exam works correctly with their custom script hacks removed.